### PR TITLE
Fix: Entity 수정

### DIFF
--- a/src/main/java/com/showrun/boxbox/domain/FanRadio.java
+++ b/src/main/java/com/showrun/boxbox/domain/FanRadio.java
@@ -71,7 +71,7 @@ public class FanRadio {
 
     public void addUser(User user) {
         this.user = user;
-        user.addFanRadio(this);
+        user.getFanRadios().add(this); // ✅ 주인쪽에서만 양방향 연결
     }
 
     public FanRadio update(String radioTextKor, String radioTextEng){

--- a/src/main/java/com/showrun/boxbox/domain/User.java
+++ b/src/main/java/com/showrun/boxbox/domain/User.java
@@ -84,7 +84,6 @@ public class User {
 
     public void addFanRadio(FanRadio fanRadio) {
         this.fanRadios.add(fanRadio);
-        fanRadio.addUser(this);
     }
 
     public User update(Status userStatus, LocalDateTime userLastLoginAt){


### PR DESCRIPTION
## ✨ 요약
- `POST /radio/create-radio` 호출 시 발생한 **StackOverflowError**를 해결
- 원인: `User` ↔ `FanRadio` 양방향 연관관계 편의 메서드가 서로 무한 호출
- 해결: **연관관계 주인(FanRadio.user)** 쪽에서만 편의 메서드 유지하도록 수정

---

## 💻 작업 내용
- [x] `User.addFanRadio()`에서 `fanRadio.addUser(this)` 호출 제거
- [x] `FanRadio.addUser()`에서만 `user.getFanRadios().add(this)` 동기화 유지
- [x] 무한 재귀 발생 원인 분석 및 트러블 슈팅 문서화
- [x] 양방향 연관관계 편의 메서드 작성 규칙 정리

---

## 💬 리뷰 요청 사항 (Optional)
- 현재는 `FanRadio.user`가 `@ManyToOne` 주인이므로 한쪽만 편의 메서드를 유지했는데, 이 구조가 프로젝트 전체 연관관계 설계 기준에 부합하는지 확인 부탁드립니다.
- 혹시 더 안전한 유틸 메서드 작성 방식이나 팀 내 공통 컨벤션이 필요하다면 논의하면 좋겠습니다.

---

## 📚 참고 자료 (Optional)
- [트러블 슈팅 TIP: 양방향 연관관계 편의 메서드 무한 호출 문제](https://velog.io/@0like/%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85-TIP-%EC%9E%91%EC%84%B1-%EA%B0%80%EC%9D%B4%EB%93%9C-%ED%85%9C%ED%94%8C%EB%A6%BF)